### PR TITLE
Fix html `lang` attribute accessibility issue

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	i18n: {
+		// These are all the locales you want to support in
+		// your application
+		locales: ["en-US"],
+		// This is the default locale you want to be used when visiting
+		// a non-locale prefixed path e.g. `/hello`
+		defaultLocale: "en-US",
+	},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "react-indy-website-fork",
+	"name": "reactindy-website",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {


### PR DESCRIPTION
Add basic i18n config to fix the missing `lang` attribute on the root html tag.

Fix #29 